### PR TITLE
[wip] testing chunked transfer encoding

### DIFF
--- a/pack.toml
+++ b/pack.toml
@@ -8,3 +8,7 @@ test = "tests/http-test.ipkg"
 type = "local"
 path = "tests"
 ipkg = "http-test.ipkg"
+
+[idris2]
+url="https://github.com/jarlah/Idris2-httpfix"
+commit="7b4590216c6504c3d1e4d1cbc33f3a2d86daba17"

--- a/pack.toml
+++ b/pack.toml
@@ -11,4 +11,4 @@ ipkg = "http-test.ipkg"
 
 [idris2]
 url="https://github.com/jarlah/Idris2-httpfix"
-commit="7b4590216c6504c3d1e4d1cbc33f3a2d86daba17"
+commit="fa50df76de7892dc42f5588a36fb5657a4299242"

--- a/src/Network/HTTP/Error.idr
+++ b/src/Network/HTTP/Error.idr
@@ -14,6 +14,7 @@ data HttpError e
   | MissingHeader String
   | UnknownTransferEncoding String
   | DecompressionError String
+  | TimedOutError String
   | OtherReason e
 
 %runElab derive "HttpError" [Eq, Show]

--- a/src/Network/HTTP/Scheduler.idr
+++ b/src/Network/HTTP/Scheduler.idr
@@ -12,6 +12,7 @@ import Data.Compress.GZip
 import Data.Compress.ZLib
 import Data.String
 import System.Concurrency
+import Network.HTTP.Status
 
 public export
 record ScheduleResponse (e : Type) (m : Type -> Type) where
@@ -63,6 +64,18 @@ to_list : Maybe (List1 a) -> List a
 to_list Nothing = []
 to_list (Just (x ::: xs)) = x :: xs
 
+
+accumulateResponse2 : (HasIO m, Scheme a) => Channel a -> List a -> m (Either (HttpError e) (HttpResponse, List a))
+accumulateResponse2 chan acc = do
+  maybeChunk <- channelGetNonBlocking chan
+  case maybeChunk of
+    Nothing => 
+      if null acc
+        then pure $ Left $ SocketError "No data received"
+        else pure $ Right (MkHttpResponse (MkDPair 200 OK) "" [], acc)
+    Just chunk => accumulateResponse chan (acc ++ [chunk])
+
+
 public export
 start_request : {m, e : _} -> (HasIO m, Scheduler e m scheduler) =>
           scheduler ->
@@ -73,7 +86,14 @@ start_request : {m, e : _} -> (HasIO m, Scheduler e m scheduler) =>
 start_request scheduler protocol msg content = do
   mvar <- makeChannel
   schedule_request scheduler protocol $ MkScheduleRequest msg content mvar
-  Right response <- channelGet mvar
-  | Left err => pure $ Left err
-  let (encoding ** wit) = decompressor $ to_list $ lookup_header response.raw_http_response.headers ContentEncoding
-  pure $ Right (response.raw_http_response, channel_to_stream (init @{wit}) response.content)
+  result <- accumulateResponse2 mvar []
+  case result of
+    Left err => pure $ Left err
+    Right (response, accumulatedContent) =>
+      let (encoding ** wit) = decompressor $ to_list $ lookup_header response.headers ContentEncoding
+      in pure $ Right (response, channel_to_stream (init @{wit}) (streamFromList accumulatedContent))
+
+where
+  streamFromList : List a -> Stream (Of a) m (Either (HttpError e) ())
+  streamFromList [] = pure $ Right ()
+  streamFromList (x :: xs) = x `cons` streamFromList xs

--- a/src/Network/HTTP/Scheduler.idr
+++ b/src/Network/HTTP/Scheduler.idr
@@ -10,6 +10,8 @@ import Data.List1
 import Data.Compress.Interface
 import Data.Compress.GZip
 import Data.Compress.ZLib
+import Data.String
+import System.Concurrency
 
 public export
 record ScheduleResponse (e : Type) (m : Type -> Type) where
@@ -34,16 +36,23 @@ interface Scheduler (e : Type) (m : Type -> Type) (0 a : Type) where
 channel_to_stream : (HasIO m, Decompressor c) => c -> Channel (Either (HttpError e) (Maybe (List Bits8))) ->
                     Stream (Of Bits8) m (Either (HttpError e) ())
 channel_to_stream decomp channel = do
-  Right (Just content) <- liftIO $ channelGet channel
-  | Right Nothing =>
+  putStrLn "Asking for data"
+  result <- liftIO $ channelGet channel
+  putStrLn "Asked for data"
+  case result of
+    Right (Just content) => do
+      putStrLn $ "got " ++ show content
+      let Right (decompressed, newDecomp) = feed decomp content
+        | Left err => pure (Left $ DecompressionError err)
+      fromList_ decompressed *> channel_to_stream newDecomp channel
+    Right Nothing => do
+      putStrLn "Got nothing"
       case done decomp of
         Right [] => pure (Right ())
         Right xs => pure (Left $ DecompressionError "\{show $ length xs} leftover bytes in decompression buffer")
         Left err => pure (Left $ DecompressionError err)
-  | Left err => pure (Left err)
-  let Right (content, decomp) = feed decomp content
-  | Left err => pure (Left $ DecompressionError err)
-  fromList_ content *> channel_to_stream decomp channel
+    Left err => pure (Left err)
+
 
 decompressor : List ContentEncodingScheme -> DPair Type Decompressor
 decompressor [ GZip ] = MkDPair GZipState %search

--- a/src/Network/HTTP/Scheduler.idr
+++ b/src/Network/HTTP/Scheduler.idr
@@ -73,7 +73,7 @@ accumulateResponse2 chan acc = do
       if null acc
         then pure $ Left $ SocketError "No data received"
         else pure $ Right (MkHttpResponse (MkDPair 200 OK) "" [], acc)
-    Just chunk => accumulateResponse chan (acc ++ [chunk])
+    Just chunk => accumulateResponse2 chan (acc ++ [chunk])
 
 
 public export

--- a/src/Test.idr
+++ b/src/Test.idr
@@ -1,0 +1,27 @@
+module Test
+
+import Data.Nat 
+import Network.HTTP
+import Control.Monad.Error.Either
+import Control.Monad.Error.Interface
+
+ResultMonad : Type -> Type
+ResultMonad = EitherT (HttpError ()) IO
+
+getClient: IO (HttpClient ())
+getClient = new_client certificate_ignore_check 1 1 False False
+
+performRequest : HttpClient () -> ResultMonad (HttpResponse, Stream (Of Bits8) ResultMonad ())
+performRequest client = 
+  request client GET (url' "https://anglesharp.azurewebsites.net/Chunked") [("Authorization", "Bearer foo")] ()
+
+silly_me = do
+    client <- getClient
+    Right (result, stream) <- runEitherT $ performRequest client
+      | Left e => printLn $ "Error from calling url " ++ show e
+    putStrLn $ show result
+    Right (content, _) <- runEitherT $ toList stream
+      | Left e => printLn $ "Error from reading response stream "  ++ show e   
+    putStrLn $ show content
+    putStrLn "Done"
+    close client


### PR DESCRIPTION
```
pack repl src/Test.idr 
Test> :exec silly_me
MkHttpResponse {status_code = (200 ** OK), status_name = "OK", headers = [("Content-Type", "text/html"), ("Date", "Sun, 24 Nov 2024 07:44:46 GMT"), ("Server", "Microsoft-IIS/10.0"), ("Cache-Control", "private"), ("Set-Cookie", "ARRAffinity=5c3b3eeb308eb53980891741456831fd17b082f53c89f03c9c9dcc2d905209a3;Path=/;HttpOnly;Secure;Domain=anglesharp.azurewebsites.net"), ("Set-Cookie", "ARRAffinitySameSite=5c3b3eeb308eb53980891741456831fd17b082f53c89f03c9c9dcc2d905209a3;Path=/;HttpOnly;SameSite=None;Secure;Domain=anglesharp.azurewebsites.net"), ("Transfer-Encoding", "chunked"), ("X-AspNetMvc-Version", "5.0"), ("X-AspNet-Version", "4.0.30319"), ("X-Powered-By", "ASP.NET")]}
Asking for data
Asked for data
got [60, 33, 68, 79, 67, 84, 89, 80, 69, 32, 104, 116, 109, 108, 62, 13, 10, 60, 104, 116, 109, 108, 32, 108, 97, 110, 103, 61, 101, 110, 62, 13, 10, 60, 104, 101, 97, 100, 62, 13, 10, 60, 109, 101, 116, 97, 32, 99, 104, 97, 114, 115, 101, 116, 61, 39, 117, 116, 102, 45, 56, 39, 62, 13, 10, 60, 116, 105, 116, 108, 101, 62, 67, 104, 117, 110, 107, 101, 100, 32, 116, 114, 97, 110, 115, 102, 101, 114, 32, 101, 110, 99, 111, 100, 105, 110, 103, 32, 116, 101, 115, 116, 60, 47, 116, 105, 116, 108, 101, 62, 13, 10, 60, 47, 104, 101, 97, 100, 62, 13, 10, 60, 98, 111, 100, 121, 62]
Asking for data
.... hangs forever and ever and ever ...
```

the bytes is this 

```
<!DOCTYPE html>
<html lang=en>
<head>
<meta charset='utf-8'>
<title>Chunked transfer encoding test</title>
</head>
<body>
```